### PR TITLE
Fix "Insert Image" drag command issues when filename/path contains special characters

### DIFF
--- a/DragCommands/Image Tag.plist
+++ b/DragCommands/Image Tag.plist
@@ -1,18 +1,37 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>command</key>
-	<string>img="$TM_DROPPED_FILE"
-echo -n "&lt;img src=\"$img\" "
+	<string>#!/usr/bin/env ruby -wKU
+require "#{ENV['TM_SUPPORT_PATH']}/lib/escape"
+require "shellwords"
+require "CGI"
 
-sips -g pixelWidth -g pixelHeight "$img" \
-|awk '/pixelWidth/  { printf("width=\"%d\" ",  $2) }
-      /pixelHeight/ { printf("height=\"%d\" ", $2) }'
+def tag_for_file(file, tab_stop = 0)
+    file_path = File.expand_path file
 
-base=${img##*/}
-alt=$(tr &lt;&lt;&lt;${base%.*} '[_-]' ' '|perl -pe 's/(\w+)/\u$1/g')
-echo -n "alt=\"$alt\"${TM_XHTML}&gt;"
+	tag = "&lt;img src=\"#{e_sn(CGI::escapeHTML file)}\""
+
+	dim = %x{ sips -g pixelWidth -g pixelHeight #{e_sh file_path} }
+	tag &lt;&lt; " width=\"#$1\""  if dim =~ /pixelWidth: (\d+)/
+	tag &lt;&lt; " height=\"#$1\"" if dim =~ /pixelHeight: (\d+)/
+
+    alt = File.basename(file, File.extname(file))
+    alt = alt.gsub(/[_-]+/, ' ').strip.gsub(/\b[a-z]/) { $&amp;.upcase }
+	tag &lt;&lt; " alt=\"\${#{tab_stop+1}:#{e_snp(CGI::escapeHTML alt)}}\""
+
+	tag &lt;&lt; "#{ENV['TM_XHTML']}&gt;"
+end
+
+if ENV.has_key? 'TM_DROPPED_FILES'
+	files = Shellwords.shellwords(ENV['TM_DROPPED_FILES'])
+	files.each_with_index do |file, tab_stop|
+		STDOUT &lt;&lt; tag_for_file(file, tab_stop) &lt;&lt; "\n"
+	end
+else
+	STDOUT &lt;&lt; tag_for_file(ENV['TM_DROPPED_FILE'])
+end
 </string>
 	<key>draggedFileExtensions</key>
 	<array>


### PR DESCRIPTION
The following filenames were previously causing issues:

```
'-dir/foo.jpg'
'-foo.jpg'
'$foo.jpg'
'foo">bar.jpg'
```

All should work now.
