### PR TITLE
Allow lowercase doctype as it's valid HTML5.

### DIFF
--- a/Syntaxes/HTML.plist
+++ b/Syntaxes/HTML.plist
@@ -16,7 +16,7 @@
 		<string>ctp</string>
 	</array>
 	<key>firstLineMatch</key>
-	<string>&lt;!DOCTYPE|&lt;(?i:html)|&lt;\?(?i:php)</string>
+	<string>&lt;!(DOCTYPE|doctype)|&lt;(?i:html)|&lt;\?(?i:php)</string>
 	<key>foldingStartMarker</key>
 	<string>(?x)
 		(&lt;(?i:head|body|table|thead|tbody|tfoot|tr|div|section|article|aside|header|footer|nav|menu|select|fieldset|style|script|ul|ol|li|form|dl)\b.*?&gt;
@@ -178,7 +178,7 @@
 			<array>
 				<dict>
 					<key>begin</key>
-					<string>(DOCTYPE)</string>
+					<string>(DOCTYPE|doctype)</string>
 					<key>captures</key>
 					<dict>
 						<key>1</key>


### PR DESCRIPTION
`<!DOCTYPE>` works (TM highlights it), `<!doctype>` doesn't (TM thinks it's error).

This patch allows lower-case doctypes.
