### PR TITLE
Added scope restriction to body trigger.

### DIFF
--- a/Snippets/XHTML <body>.plist
+++ b/Snippets/XHTML <body>.plist
@@ -9,7 +9,7 @@
 	<key>name</key>
 	<string>Body</string>
 	<key>scope</key>
-	<string>text.html</string>
+	<string>text.html - meta.tag</string>
 	<key>tabTrigger</key>
 	<string>body</string>
 	<key>uuid</key>


### PR DESCRIPTION
Body trigger would activate when inside a <body> tag rather than tabbing into the content of said tag. By limiting the scope to eliminate it's use when already in a tag this behavior is prevented.
