### PR TITLE
Added scope limitation to h1 trigger

### DIFF
--- a/Snippets/XHTML <h1>.plist
+++ b/Snippets/XHTML <h1>.plist
@@ -7,7 +7,7 @@
 	<key>name</key>
 	<string>Heading</string>
 	<key>scope</key>
-	<string>text.html</string>
+	<string>text.html - meta.tag</string>
 	<key>tabTrigger</key>
 	<string>h1</string>
 	<key>uuid</key>


### PR DESCRIPTION
H1 trigger would activate when inside an H1 tag rather than tabbing into the content of said tag. By limiting the scope to eliminate it's use when already in a tag this behavior is prevented.
