### PR TITLE
Update tags in “Convert to named entities excl tags”

### DIFF
--- a/Commands/Convert to named entities excl tags.plist
+++ b/Commands/Convert to named entities excl tags.plist
@@ -24,7 +24,7 @@ STDIN.read.scan(/(?x)
 
     ( &lt;\?(?:[^?]*|\?(?!&gt;))*\?&gt;
     | &lt;!-- (?m:.*?) --&gt;
-    | &lt;\/? (?i:a|abbr|acronym|address|applet|area|b|base|basefont|bdo|big|blockquote|body|br|button|caption|center|cite|code|col|colgroup|dd|del|dfn|dir|div|dl|dt|em|fieldset|font|form|frame|frameset|h1|h2|h3|h4|h5|h6|head|hr|html|i|iframe|img|input|ins|isindex|kbd|label|legend|li|link|map|menu|meta|noframes|noscript|object|ol|optgroup|option|p|param|pre|q|s|samp|script|select|small|span|strike|strong|style|sub|sup|table|tbody|td|textarea|tfoot|th|thead|title|tr|tt|u|ul|var)\b
+    | &lt;\/? (?i:a|abbr|acronym|address|applet|area|article|aside|audio|b|base|basefont|bdi|bdo|bgsound|big|blink|blockquote|body|br|button|canvas|caption|center|cite|code|col|colgroup|content|data|datalist|dd|decorator|del|details|dfn|dir|div|dl|dt|element|em|embed|fieldset|figcaption|figure|font|footer|form|frame|frameset|h1|h2|h3|h4|h5|h6|head|header|hgroup|hr|html|i|iframe|img|input|ins|isindex|kbd|keygen|label|legend|li|link|listing|main|map|mark|marquee|menu|menuitem|meta|meter|nav|nobr|noframes|noscript|object|ol|optgroup|option|output|p|param|plaintext|pre|progress|q|rp|rt|ruby|s|samp|script|section|select|shadow|small|source|spacer|span|strike|strong|style|sub|summary|sup|table|tbody|td|template|textarea|tfoot|th|thead|time|title|tr|track|tt|u|ul|var|video|wbr|xmp)\b
         (?:[^&gt;"']|"[^"]*"|'[^']*')*
       &gt;
     | &amp;(?:[a-zA-Z0-9]+|\#[0-9]+|\#x[0-9a-fA-F]+);


### PR DESCRIPTION
The “Convert to named entities excl tags” menu action’s whitelist of tags to filter out predated the HTML5 spec and didn’t support its new tags. Prior to this commit this sample markup:

`<section>I’m markup!</section>`

would convert to:

`&lt;section&gt;I&rsquo;m markup!&lt;/section&gt;`

But with this change it correctly converts to:

`<section>I&rsquo;m markup!</section>`

Complete tag list provided by https://developer.mozilla.org/en-US/docs/Web/HTML/Element. This includes tags deprecated by HTML5, those introduced by it, as well as the WebComponents spec.
