### PR TITLE
Restrict scope of embedded JavaScript

### DIFF
--- a/Syntaxes/HTML.plist
+++ b/Syntaxes/HTML.plist
@@ -275,7 +275,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>(?:^\s+)?(&lt;)((?i:script))\b(?![^&gt;]*/&gt;)</string>
+			<string>(?:^\s+)?(&lt;)((?i:script))\b(?![^&gt;]*/&gt;)(?![^&gt;]*(?i:type.?=.?text/((?!javascript).*)))</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>


### PR DESCRIPTION
Should match every proper case now:
- lower case / upper case
- single and double quotes and leaving quotes out (see HTML5 spec) after the type attribute
- without type attribute (defaults to JavaScript as of HTML5)

Closes #22
