### PR TITLE
Removed charset on inline script tag

### DIFF
--- a/Snippets/XHTML <script>.plist
+++ b/Snippets/XHTML <script>.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>content</key>
-	<string>&lt;script type="text/javascript" charset="utf-8"&gt;
+	<string>&lt;script type="text/javascript"&gt;
 	$0
 &lt;/script&gt;</string>
 	<key>name</key>


### PR DESCRIPTION
See [this article on html optimization](http://perfectionkills.com/optimizing-html/#8_script_charset) for the rationale on this.
