### PR TITLE
Match HTML DOCTYPE insensitive of case

### DIFF
--- a/Syntaxes/HTML.plist
+++ b/Syntaxes/HTML.plist
@@ -16,7 +16,7 @@
 		<string>ctp</string>
 	</array>
 	<key>firstLineMatch</key>
-	<string>&lt;!DOCTYPE|&lt;(?i:html)|&lt;\?(?i:php)</string>
+	<string>&lt;!(?i:DOCTYPE)|&lt;(?i:html)|&lt;\?(?i:php)</string>
 	<key>foldingStartMarker</key>
 	<string>(?x)
 		(&lt;(?i:head|body|table|thead|tbody|tfoot|tr|div|section|article|aside|header|footer|nav|menu|select|fieldset|style|script|ul|ol|li|form|dl)\b.*?&gt;
@@ -178,7 +178,7 @@
 			<array>
 				<dict>
 					<key>begin</key>
-					<string>(DOCTYPE)</string>
+					<string>(?i:DOCTYPE)</string>
 					<key>captures</key>
 					<dict>
 						<key>1</key>


### PR DESCRIPTION
This allows for case insensitive matches of the start of the HTML DOCTYPE.

From the HTML 5 spec ([link](http://www.w3.org/TR/2014/CR-html5-20140731/syntax.html#the-doctype)):

> A DOCTYPE must consist of the following components, in this order:
> 1. A string that is an ASCII case-insensitive match for the string "`<!DOCTYPE`".

The closest thing I could find to a syntax for the HTML 4 DOCTYPE says ([link](http://www.w3.org/TR/html-markup/syntax.html#doctype-syntax)):

> A deprecated doctype consists of the following parts, in exactly the following order:
> 1. Any case-insensitive match for the string "`<!DOCTYPE`".
> 
> A legacy-tool-compatible doctype consists of the following parts, in exactly the following order:
> 1. Any case-insensitive match for the string "`<!DOCTYPE`".
