### PR TITLE
Folding support for PHP 5.4 short array syntax

### DIFF
--- a/Preferences/Folding.tmPreferences
+++ b/Preferences/Folding.tmPreferences
@@ -17,6 +17,7 @@
 		|\{\{?(if|foreach|capture|literal|foreach|php|section|strip)
 		|\{\s*($|\?&gt;\s*$|//|/\*(.*\*/\s*$|(?!.*?\*/)))
 		|array\s?\(\s*$
+		|\[\s*$
 		)</string>
 		<key>foldingStopMarker</key>
 		<string>(?x)
@@ -27,6 +28,7 @@
 		|\{\{?/(if|foreach|capture|literal|foreach|php|section|strip)
 		|^[^{]*\}
 		|^\s*\)[,;]
+		|^\s*\][,;]
 		)</string>
 	</dict>
 	<key>uuid</key>


### PR DESCRIPTION
See http://php.net/manual/en/migration54.new-features.php for information.

- Identical syntax to existing folding for **array( ... )[,;]**