### PR TITLE
Remove title and charset attributes from link tags

### DIFF
--- a/Snippets/XHTML <link>.plist
+++ b/Snippets/XHTML <link>.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>content</key>
-	<string>&lt;link rel="${1:stylesheet}" href="${2:/css/master.css}" type="text/css" media="${3|screen,all,braille,embossed,handheld,print,projection,speech,tty,tv|}" title="${4:no title}" charset="${5:utf-8}"${TM_XHTML}&gt;</string>
+	<string>&lt;link rel="${1:stylesheet}" href="${2:/css/master.css}" type="text/css" media="${3|screen,all,braille,embossed,handheld,print,projection,speech,tty,tv|}"${TM_XHTML}&gt;</string>
 	<key>name</key>
 	<string>Link</string>
 	<key>scope</key>


### PR DESCRIPTION
While 'charset' is plainly discouraged (https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#attr-charset), title attribute on link tags is something rarely used and with implications that authors might not be aware of (http://stackoverflow.com/a/1959975/1092853).
