### PR TITLE
Remove title and charset on link tags

### DIFF
--- a/DragCommands/CSS Link.plist
+++ b/DragCommands/CSS Link.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>command</key>
-	<string>echo "&lt;link rel=\"stylesheet\" href=\"$TM_DROPPED_FILE\" type=\"text/css\" media=\"screen\" title=\"no title\" charset=\"utf-8\"$TM_XHTML&gt;"</string>
+	<string>echo "&lt;link rel=\"stylesheet\" href=\"$TM_DROPPED_FILE\" type=\"text/css\" media=\"screen\"$TM_XHTML&gt;"</string>
 	<key>draggedFileExtensions</key>
 	<array>
 		<string>css</string>


### PR DESCRIPTION
Same result of https://github.com/textmate/html.tmbundle/pull/36, but for drag-and-dropped stylesheets