### PR TITLE
Change regex to match HTML tags better

### DIFF
--- a/Preferences/Miscellaneous.plist
+++ b/Preferences/Miscellaneous.plist
@@ -37,7 +37,7 @@
 			</array>
 			<array>
 				<string>/&lt;(?!area|base|basefont|br|col|frame|hr|img|input|isindex|link|meta|param)\w+[^&gt;]*(?&lt;!/)&gt;/</string>
-				<string>/&lt;/\w+&gt;/</string>
+				<string>/&lt;/\S+&gt;/</string>
 			</array>
 		</array>
 		<key>increaseIndentPattern</key>


### PR DESCRIPTION
Since 04a714a465f7deba2c0618a0024adc843c93e805 one can use Select Enclosing Typing Pairs for HTML tags. This fails short if custom HTML tags are in between, like Angular directives (which contain dashes, "-") or some of the tags Facebook uses for its integration stuff (which contain double colons, ":").

To illustrate, behavior without this change:

<img width="965" alt="screen shot 2015-07-14 at 11 49 56" src="https://cloud.githubusercontent.com/assets/7542/8670772/f05cdf84-2a1f-11e5-84e1-6ea20f618f60.png">

After the change:

<img width="965" alt="screen shot 2015-07-14 at 11 49 06" src="https://cloud.githubusercontent.com/assets/7542/8670782/fe97c2b2-2a1f-11e5-88a4-18a9f590de71.png">
