### PR TITLE
Edit contents of tag created via ⌃W

### DIFF
--- a/Snippets/Wrap Selection In Tag.plist
+++ b/Snippets/Wrap Selection In Tag.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>content</key>
-	<string>&lt;${1:p}&gt;$TM_SELECTED_TEXT&lt;/${1/\s.*//}&gt;</string>
+	<string>&lt;${1:p}&gt;${2:$TM_SELECTED_TEXT}&lt;/${1/\s.*//}&gt;</string>
 	<key>keyEquivalent</key>
 	<string>^W</string>
 	<key>name</key>


### PR DESCRIPTION
It's now possible to: press ⌃W, type the tag name and attributes, ⇥, type it's contents, then ⇥ again to exit the tag.  Previously, it wasn't easy to reach the tag contents.

The existing functionality of having selected text then pressing ⌃W to enclose it between tags remains.
