### PR TITLE
Ignore bad angle bracket injection in javascript

### DIFF
--- a/Syntaxes/HTML.plist
+++ b/Syntaxes/HTML.plist
@@ -16,7 +16,7 @@
 	<string>&lt;(?i:(!DOCTYPE\s*)?html)</string>
 	<key>injections</key>
 	<dict>
-		<key>R:text.html - comment.block</key>
+		<key>R:text.html - (comment.block, source.js.embedded.html)</key>
 		<dict>
 			<key>comment</key>
 			<string>Use R: to ensure this matches after any other injections.</string>

--- a/Syntaxes/HTML.plist
+++ b/Syntaxes/HTML.plist
@@ -16,7 +16,7 @@
 	<string>&lt;(?i:(!DOCTYPE\s*)?html)</string>
 	<key>injections</key>
 	<dict>
-		<key>R:text.html - (comment.block, source.js.embedded.html)</key>
+		<key>R:text.html - (comment.block, source.js.embedded.html, string.quoted)</key>
 		<dict>
 			<key>comment</key>
 			<string>Use R: to ensure this matches after any other injections.</string>


### PR DESCRIPTION
The injection that detects bad left angle brackets was triggering
inside of quoted strings in embedded javascript code.
