### PR TITLE
Fix hex entities with uppercase X not recognized

### DIFF
--- a/Syntaxes/HTML.plist
+++ b/Syntaxes/HTML.plist
@@ -547,7 +547,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>(&amp;)([a-zA-Z0-9]+|#[0-9]+|#x[0-9a-fA-F]+)(;)</string>
+					<string>(&amp;)([a-zA-Z0-9]+|#[0-9]+|#[x|X][0-9a-fA-F]+)(;)</string>
 					<key>name</key>
 					<string>constant.character.entity.html</string>
 				</dict>


### PR DESCRIPTION
TextMate recognizes `&#x000BE;` but not `&#X000BE;`