### PR TITLE
Remove error highlight for dashes in comments and CDATA sections

### DIFF
--- a/Syntaxes/HTML.plist
+++ b/Syntaxes/HTML.plist
@@ -136,14 +136,14 @@
 				</dict>
 			</dict>
 			<key>end</key>
-			<string>--\s*&gt;</string>
+			<string>--!?&gt;</string>
 			<key>name</key>
 			<string>comment.block.html</string>
 			<key>patterns</key>
 			<array>
 				<dict>
 					<key>match</key>
-					<string>--</string>
+					<string>&lt;!--</string>
 					<key>name</key>
 					<string>invalid.illegal.bad-comments-or-CDATA.html</string>
 				</dict>
@@ -202,12 +202,6 @@
 					<string>]](?=&gt;)</string>
 					<key>name</key>
 					<string>constant.other.inline-data.html</string>
-				</dict>
-				<dict>
-					<key>match</key>
-					<string>(\s*)(?!--|&gt;)\S(\s*)</string>
-					<key>name</key>
-					<string>invalid.illegal.bad-comments-or-CDATA.html</string>
 				</dict>
 			</array>
 		</dict>


### PR DESCRIPTION
Fixes #45.

The check for CDATA sections was bogus to begin with, as far as I
can tell. They have always allowed dashes and > per spec.