### PR TITLE
This adds babel support to html scripts

### DIFF
--- a/Syntaxes/HTML.plist
+++ b/Syntaxes/HTML.plist
@@ -537,7 +537,7 @@
 									<key>begin</key>
 									<string>\G</string>
 									<key>end</key>
-									<string>(?i:(?=/?&gt;|type(?=[\s=])(?!\s*=\s*('|"|)(text/(javascript|ecmascript)|application/((x-)?javascript|ecmascript)|module)[\s"'&gt;])))</string>
+									<string>(?i:(?=/?&gt;|type(?=[\s=])(?!\s*=\s*('|"|)(text/(javascript|ecmascript|babel)|application/((x-)?javascript|ecmascript|babel)|module)[\s"'&gt;])))</string>
 									<key>name</key>
 									<string>meta.tag.metadata.script.html</string>
 									<key>patterns</key>


### PR DESCRIPTION
This line makes highlighting work for Babel scripts so you can work with React etc in html files if you want to.

I was asked over at https://github.com/Microsoft/vscode/pull/26632#event-1081820918 to create a pull request here.

I had been manually changing this in my VS Code files, but every time I update VS Code I have to change this again.