### PR TITLE
Fix URL Escaping of non-ASCII characters

### DIFF
--- a/Commands/Convert Line : Selection to URL Escapes.plist
+++ b/Commands/Convert Line : Selection to URL Escapes.plist
@@ -7,9 +7,9 @@
 	<key>command</key>
 	<string>#!/usr/bin/env ruby20
 
-print STDIN.read.gsub(/([^a-zA-Z0-9_.-]+)/n) {
-  '%' + $1.unpack('H2' * $1.size).join('%').upcase
-}
+require "uri"
+
+print URI.encode_www_form_component(STDIN.read)
 </string>
 	<key>fallbackInput</key>
 	<string>line</string>


### PR DESCRIPTION
If I start with this text:

    я твой работник

and select Bundles > HTML > URL Escapes > URL Escape Line, I get this:

    %D1%8F%20%D1%82%D0%B2%D0%BE%D0%B9%20%D1%80%D0

…which is incomplete — the last word is cut off.  It decodes as this:

    я твой р

This PR uses Ruby's URI module to perform the encoding (instead of incorrectly reimplementing it), which properly encodes that text as this:

    %D1%8F+%D1%82%D0%B2%D0%BE%D0%B9+%D1%80%D0%B0%D0%B1%D0%BE%D1%82%D0%BD%D0%B8%D0%BA

Tested using TextMate 2.0-rc.19 on macOS 10.14.2.