### PR TITLE
To Fix inline javaScript event layout {microsoft/vscode/issues/112189)

### DIFF
--- a/Syntaxes/HTML.plist
+++ b/Syntaxes/HTML.plist
@@ -356,7 +356,7 @@
 														</dict>
 													</dict>
 													<key>match</key>
-													<string>([^\n"/]|/(?![/*]))+</string>
+													<string>([^\n"/]|/)+</string>
 												</dict>
 												<dict>
 													<key>begin</key>
@@ -447,7 +447,7 @@
 														</dict>
 													</dict>
 													<key>match</key>
-													<string>([^\n'/]|/(?![/*]))+</string>
+													<string>([^\n'/]|/)+</string>
 												</dict>
 												<dict>
 													<key>begin</key>

--- a/Syntaxes/HTML.plist
+++ b/Syntaxes/HTML.plist
@@ -356,7 +356,7 @@
 														</dict>
 													</dict>
 													<key>match</key>
-													<string>([^\n"/]|/)+</string>
+													<string>([^\n"])+</string>
 												</dict>
 												<dict>
 													<key>begin</key>
@@ -447,7 +447,7 @@
 														</dict>
 													</dict>
 													<key>match</key>
-													<string>([^\n'/]|/)+</string>
+													<string>([^\n'])+</string>
 												</dict>
 												<dict>
 													<key>begin</key>


### PR DESCRIPTION
Works fine now for both single and double quotes

Will fix the issue at https://github.com/microsoft/vscode/issues/112189

#### Currently :

![earlierInlineJs](https://user-images.githubusercontent.com/24385409/103143733-8afa3880-4742-11eb-918c-15ef37048cec.JPG)

#### After change :

![InlineJs](https://user-images.githubusercontent.com/24385409/103143708-0f988700-4742-11eb-9fbc-1db54060c9b7.JPG)

