### PR TITLE
Update HTML.plist - allow embedding of typescript in HTML <script> tags

### DIFF
--- a/Syntaxes/HTML.plist
+++ b/Syntaxes/HTML.plist
@@ -3091,6 +3091,7 @@
 																  | x-javascript
 																  | jscript
 																  | livescript
+																  | typescript
 																  | (x-)?ecmascript
 																  | babel						# Javascript variant currently
 																  								#   recognized as such


### PR DESCRIPTION
In VSCode, if I use a `<script type="text/typescript">` tag, I loose my syntax highlighting within the tag. Adding making this change re-enables it.